### PR TITLE
Features/create own config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,21 @@ via composer:
 composer require medkad/laravel-isms
 ```
 
+### Publish iSMS Config File
+
+``` bash
+php artisan vendor:publish --provider="Medkad\ISMS\ISMSServiceProvider"
+```
 ### Setting up your configuration
 
-Add your ISMS Account credentials to your `config/services.php` and `.env`(recommended):
+Add your ISMS Account credentials to your `config/isms.php`:
 
 ```php
-// config/services.php
+// config/isms.php
 ...
-'isms' => [
     'username'  =>  env('ISMS_USERNAME', 'medkad'),
     'password'  =>  env('ISMS_PASSWORD', 'password'),
     'url'   =>  env('ISMS_URL', 'https://www.isms.com.my/RESTAPI.php'),
-],
 ...
 ```
 

--- a/src/Exceptions/ISMSException.php
+++ b/src/Exceptions/ISMSException.php
@@ -5,7 +5,7 @@ class ISMSException extends \Exception
 {
     public static function invalidConfiguration()
     {
-        return new static('Configuration for iSMS is not set! Setup your configuration at `config/services.php`. You need to add credentials in the `isms` key of `config.services`.');
+        return new static('Configuration for iSMS is not set! Setup your configuration at `config/isms.php`. You need to add credentials in the `config/isms.php`.');
     }
 
     public static function couldNotSend($code, $msg)

--- a/src/ISMSServiceProvider.php
+++ b/src/ISMSServiceProvider.php
@@ -8,10 +8,19 @@ class ISMSServiceProvider extends ServiceProvider
 {
     public function boot()
     {
+        $this->mergeConfigFrom(
+            __DIR__ . '/config/isms.php',
+            'isms'
+        );
+
+        $this->publishes([
+            __DIR__ . '/config/isms.php' => config_path('isms.php')
+        ]);
+
         $this->app->when(ISMSChannel::class)
             ->needs(ISMSClient::class)
             ->give(function () {
-                $config = config('services.isms');
+                $config = config('isms');
                 if (is_null($config)) {
                     throw ISMSException::invalidConfiguration();
                 }

--- a/src/config/isms.php
+++ b/src/config/isms.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'username'  =>  env('ISMS_USERNAME', 'medkad'),
+    'password'  =>  env('ISMS_PASSWORD', 'password'),
+    'url'   =>  env('ISMS_URL', 'https://www.isms.com.my/RESTAPI.php'),
+    
+];


### PR DESCRIPTION
##### Problem

Adding config to `config/services.php` might be troublesome and confusing if the base system might have other config keys and credentials

##### Solution

- [x] Adding own `config/isms.php`
- [x] Publish using command - boot on Service Provider
- [x] Exception handler (fix path) 